### PR TITLE
Refactor startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ This phase focuses on general cleanup and refactoring from the source
     dedicated logger like Bunyan or Pino.
 * [x] Shorten the WebID Profile URL template for new accounts from
     `/profile/card#me` to `/web#id`
-* [ ] Simplify the new account templating system
+* [x] Simplify the new account templating system (do not create template and
+    view copies for customizability)
 * [ ] Update `node-mailer` package to latest version
 * [ ] Update `inquirer` to package latest version
 

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -1,9 +1,7 @@
 module.exports = createApp
 
 const express = require('express')
-const session = require('express-session')
 const handlebars = require('express-handlebars')
-const uuid = require('uuid')
 const { addLdpMiddleware } = require('./data-storage/api')
 const SolidHost = require('./solid-host')
 const { AccountManager } = require('./account-mgmt/account-manager')
@@ -15,7 +13,6 @@ const ShareRequest = require('./authorization/share-request')
 const errorPages = require('./error-pages')
 const config = require('./server-config')
 const defaults = require('./defaults')
-const { logger } = require('./logger')
 const path = require('path')
 const bodyParser = require('body-parser')
 const { ldpRequestHandler } = require('./data-storage/api')
@@ -122,30 +119,13 @@ function initViews (app, configPath) {
  * @param storage {StorageManager}
  */
 function initWebId (argv, app, storage) {
+  const { host } = argv
   config.ensureWelcomePage({ argv, storage })
 
   // Store the user's session key in a cookie
   // (for same-domain browsing by people only)
   const useSecureCookies = !!argv.sslKey // use secure cookies when over HTTPS
-  const sessionHandler = session(sessionSettings(useSecureCookies, argv.host))
-  app.use((req, res, next) => {
-    sessionHandler(req, res, () => {
-      // Reject cookies from third-party applications.
-      // Otherwise, when a user is logged in to their Solid server,
-      // any third-party application could perform authenticated requests
-      // without permission by including the credentials set by the Solid server.
-      const origin = req.headers.origin
-      const userId = req.session.userId
-      if (!argv.host.allowsSessionFor(userId, origin)) {
-        logger.warn(`Rejecting session for ${userId} from ${origin}`)
-        // Destroy session data
-        delete req.session.userId
-        // Ensure this modified session is not saved
-        req.session.save = (done) => done()
-      }
-      next()
-    })
-  })
+  config.initSessionHandler({ app, useSecureCookies, host })
 
   const accountManager = AccountManager.from({
     authMethod: argv.auth,
@@ -186,35 +166,6 @@ function initAuthentication (app, argv) {
     throw new Error(`Unsupported authentication scheme: ${auth}`)
   }
   authenticationApi[auth].initialize(app, argv)
-}
-
-/**
- * Returns a settings object for Express.js sessions.
- *
- * @param secureCookies {boolean}
- * @param host {SolidHost}
- *
- * @return {Object} `express-session` settings object
- */
-function sessionSettings (secureCookies, host) {
-  const sessionSettings = {
-    secret: uuid.v1(),
-    saveUninitialized: false,
-    resave: false,
-    rolling: true,
-    cookie: {
-      maxAge: 24 * 60 * 60 * 1000
-    }
-  }
-  // Cookies should set to be secure if https is on
-  if (secureCookies) {
-    sessionSettings.cookie.secure = true
-  }
-
-  // Determine the cookie domain
-  sessionSettings.cookie.domain = host.cookieDomain
-
-  return sessionSettings
 }
 
 /**

--- a/lib/create-app.js
+++ b/lib/create-app.js
@@ -26,8 +26,10 @@ function createApp (argv = {}) {
   const host = SolidHost.from(hostConfig)
   argv.host = host
 
-  const configPath = config.initConfigDir(argv)
-  argv.templates = config.initTemplateDirs(configPath)
+  argv.templates = {
+    account: path.join(__dirname, '../default-templates/new-account'),
+    email: path.join(__dirname, '../default-templates/emails')
+  }
 
   config.printDebugInfo(argv) // Prints server config
 
@@ -36,7 +38,7 @@ function createApp (argv = {}) {
   const storage = config.initStorage({ host, couchConfig: argv.couchdb })
   initAppLocals({ app, argv, storage })
   initHeaders(app)
-  initViews(app, configPath)
+  initViews(app)
   initStaticRoutes(app)
 
   // Options handler
@@ -96,10 +98,9 @@ function initAppLocals ({ app, argv, storage }) {
  * Sets up the express rendering engine and views directory.
  *
  * @param app {Function} Express.js app
- * @param configPath {string}
  */
-function initViews (app, configPath) {
-  const viewsPath = config.initDefaultViews(configPath)
+function initViews (app) {
+  const viewsPath = path.join(__dirname, '../default-views')
 
   app.set('views', viewsPath)
   app.engine('.hbs', handlebars({
@@ -119,8 +120,11 @@ function initViews (app, configPath) {
  * @param storage {StorageManager}
  */
 function initWebId (argv, app, storage) {
-  const { host } = argv
-  config.ensureWelcomePage({ argv, storage })
+  const { root, multiuser, templates, server, host, skipWelcomePage } = argv
+  if (!skipWelcomePage) {
+    // Skip creating server welcome page (useful for tests)
+    config.ensureWelcomePage({ root, multiuser, templates, server, host, storage })
+  }
 
   // Store the user's session key in a cookie
   // (for same-domain browsing by people only)
@@ -131,10 +135,10 @@ function initWebId (argv, app, storage) {
     authMethod: argv.auth,
     emailService: app.locals.emailService,
     tokenService: app.locals.tokenService,
-    host: argv.host,
-    accountTemplatePath: argv.templates.account,
+    host,
+    accountTemplatePath: templates.account,
     accountStore: storage.accountStore,
-    multiuser: argv.multiuser
+    multiuser: multiuser
   })
   app.locals.accountManager = accountManager
 
@@ -148,7 +152,7 @@ function initWebId (argv, app, storage) {
   app.post('/api/share', bodyParser.urlencoded({ extended: true }),
     (req, res, next) => ShareRequest.post(req, res).catch(next))
 
-  if (argv.multiuser) {
+  if (multiuser) {
     app.use(vhost('*', addLdpMiddleware({ corsSettings })))
   }
 }

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -75,28 +75,6 @@ function initCollectionManager ({ couchConfig }) {
 }
 
 /**
- * Ensures that a directory has been copied / initialized. Used to ensure that
- * account templates, email templates and default apps have been copied from
- * their defaults to the customizable config directory, at server startup.
- *
- * @param fromDir {string} Path to copy from (defaults)
- *
- * @param toDir {string} Path to copy to (customizable config)
- *
- * @return {string} Returns the absolute path for `toDir`
- */
-function ensureDirCopyExists (fromDir, toDir) {
-  fromDir = path.resolve(fromDir)
-  toDir = path.resolve(toDir)
-
-  if (!fs.existsSync(toDir)) {
-    fs.copySync(fromDir, toDir)
-  }
-
-  return toDir
-}
-
-/**
  * Creates (copies from the server templates dir) a Welcome index page for the
  * server root web directory, if one does not already exist. This page
  * typically has links to account signup and login, and can be overridden by
@@ -104,17 +82,17 @@ function ensureDirCopyExists (fromDir, toDir) {
  *
  * @param argv {Object} App config object
  */
-async function ensureWelcomePage ({ argv, storage }) {
-  const { multiuser, templates, server, host } = argv
-  const rootDir = path.resolve(argv.root)
-  const serverRootDir = multiuser ? path.join(rootDir, argv.host.hostname) : rootDir
+async function ensureWelcomePage ({ root, multiuser, templates, server, host, storage }) {
+  const serverTemplate = path.join(__dirname, '../default-templates/server')
+  const rootDir = path.resolve(root)
+  const serverRootDir = multiuser ? path.join(rootDir, host.hostname) : rootDir
   const existingIndexPage = path.join(serverRootDir, 'index.html')
   const packageData = require('../package.json')
 
   if (!fs.existsSync(existingIndexPage)) {
     fs.mkdirp(serverRootDir)
     await AccountTemplate.copyTemplateContainer({
-      templatePath: templates.server,
+      templatePath: serverTemplate,
       accountPath: serverRootDir
     })
     await processHandlebarFile(existingIndexPage, {
@@ -123,74 +101,6 @@ async function ensureWelcomePage ({ argv, storage }) {
       serverLogo: server ? server.logo : '',
       serverVersion: packageData.version
     })
-  }
-}
-
-/**
- * Ensures that the server config directory (something like '/etc/solid-server'
- * or './config', taken from the `configPath` config.json file) exists, and
- * creates it if not.
- *
- * @param argv
- *
- * @return {string} Path to the server config dir
- */
-function initConfigDir (argv) {
-  const configPath = path.resolve(argv.configPath)
-  fs.mkdirp(configPath)
-
-  return configPath
-}
-
-/**
- * Ensures that the customizable 'views' folder exists for this installation
- * (copies it from default views if not).
- *
- * @param configPath {string} Location of configuration directory (from the
- *   local config.json file or passed in as cli parameter)
- *
- * @return {string} Path to the views dir
- */
-function initDefaultViews (configPath) {
-  const defaultViewsPath = path.join(__dirname, '../default-views')
-  const viewsPath = path.join(configPath, 'views')
-
-  ensureDirCopyExists(defaultViewsPath, viewsPath)
-
-  return viewsPath
-}
-
-/**
- * Makes sure that the various template directories (email templates, new
- * account templates, etc) have been copied from the default directories to
- * this server's own config directory.
- *
- * @param configPath {string} Location of configuration directory (from the
- *   local config.json file or passed in as cli parameter)
- *
- * @return {Object} Returns a hashmap of template directories by type
- *   (new account, email, server)
- */
-function initTemplateDirs (configPath) {
-  const accountTemplatePath = ensureDirCopyExists(
-    path.join(__dirname, '../default-templates/new-account'),
-    path.join(configPath, 'templates', 'new-account')
-  )
-
-  const emailTemplatesPath = ensureDirCopyExists(
-    path.join(__dirname, '../default-templates/emails'),
-    path.join(configPath, 'templates', 'emails')
-  )
-
-  const serverTemplatePath = ensureDirCopyExists(
-    path.join(__dirname, '../default-templates/server'),
-    path.join(configPath, 'templates', 'server')
-  )
-
-  return {
-    account: accountTemplatePath,
-    email: emailTemplatesPath,
-    server: serverTemplatePath
   }
 }
 
@@ -248,14 +158,10 @@ function sessionSettings (secureCookies, host) {
 }
 
 module.exports = {
-  ensureDirCopyExists,
   ensureWelcomePage,
   hostConfigFor,
-  initConfigDir,
-  initDefaultViews,
   initSessionHandler,
   initStorage,
-  initTemplateDirs,
   printDebugInfo,
   sessionSettings
 }

--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -6,6 +6,8 @@
 
 const fs = require('fs-extra')
 const path = require('path')
+const uuid = require('uuid')
+const session = require('express-session')
 const { AccountTemplate, processHandlebarFile } = require('./account-mgmt/account-template')
 const LegacyResourceMapper = require('./data-storage/ldp-backend-fs/legacy-resource-mapper')
 const { StorageManager } = require('./storage-manager')
@@ -192,13 +194,68 @@ function initTemplateDirs (configPath) {
   }
 }
 
+function initSessionHandler ({ app, useSecureCookies, host }) {
+  // Store the user's session key in a cookie
+  // (for same-domain browsing by people only)
+  const sessionHandler = session(sessionSettings(useSecureCookies, host))
+  app.use((req, res, next) => {
+    sessionHandler(req, res, () => {
+      // Reject cookies from third-party applications.
+      // Otherwise, when a user is logged in to their Solid server,
+      // any third-party application could perform authenticated requests
+      // without permission by including the credentials set by the Solid server.
+      const origin = req.headers.origin
+      const userId = req.session.userId
+      if (!host.allowsSessionFor(userId, origin)) {
+        logger.warn(`Rejecting session for ${userId} from ${origin}`)
+        // Destroy session data
+        delete req.session.userId
+        // Ensure this modified session is not saved
+        req.session.save = (done) => done()
+      }
+      next()
+    })
+  })
+}
+
+/**
+ * Returns a settings object for Express.js sessions.
+ *
+ * @param secureCookies {boolean}
+ * @param host {SolidHost}
+ *
+ * @return {Object} `express-session` settings object
+ */
+function sessionSettings (secureCookies, host) {
+  const sessionSettings = {
+    secret: uuid.v1(),
+    saveUninitialized: false,
+    resave: false,
+    rolling: true,
+    cookie: {
+      maxAge: 24 * 60 * 60 * 1000
+    }
+  }
+  // Cookies should set to be secure if https is on
+  if (secureCookies) {
+    sessionSettings.cookie.secure = true
+  }
+
+  // Determine the cookie domain
+  sessionSettings.cookie.domain = host.cookieDomain
+
+  return sessionSettings
+}
+
 module.exports = {
   ensureDirCopyExists,
   ensureWelcomePage,
   hostConfigFor,
   initConfigDir,
   initDefaultViews,
+  initSessionHandler,
   initStorage,
   initTemplateDirs,
-  printDebugInfo
+  printDebugInfo,
+  sessionSettings
 }

--- a/test/integration/account-creation-oidc-test.js
+++ b/test/integration/account-creation-oidc-test.js
@@ -23,6 +23,7 @@ describe('AccountManager (OIDC account creation tests)', function () {
     auth: 'oidc',
     webid: true,
     multiuser: true,
+    skipWelcomePage: true,
     strictOrigin: true,
     dbPath,
     serverUri

--- a/test/integration/acl-oidc-test.js
+++ b/test/integration/acl-oidc-test.js
@@ -49,9 +49,7 @@ const argv = {
   sslCert: path.join(__dirname, '../keys/cert.pem'),
   webid: true,
   multiuser: true,
-  auth: 'oidc',
-  strictOrigin: true,
-  host: { serverUri }
+  skipWelcomePage: true
 }
 
 describe('ACL with WebID+OIDC over HTTP', function () {

--- a/test/integration/authentication-oidc-test.js
+++ b/test/integration/authentication-oidc-test.js
@@ -51,6 +51,7 @@ describe('Authentication API (OIDC)', () => {
     auth: 'oidc',
     webid: true,
     multiuser: false,
+    skipWelcomePage: true,
     configPath
   }
 

--- a/test/integration/capability-discovery-test.js
+++ b/test/integration/capability-discovery-test.js
@@ -19,6 +19,7 @@ describe('API', () => {
     auth: 'oidc',
     webid: true,
     multiuser: false,
+    skipWelcomePage: true,
     configPath
   }
 

--- a/test/integration/errors-oidc-test.js
+++ b/test/integration/errors-oidc-test.js
@@ -19,6 +19,7 @@ describe('OIDC error handling', function () {
     auth: 'oidc',
     webid: true,
     multiuser: false,
+    skipWelcomePage: true,
     dbPath,
     serverUri
   })

--- a/test/integration/formats-test.js
+++ b/test/integration/formats-test.js
@@ -6,6 +6,7 @@ const assert = require('chai').assert
 describe('formats', function () {
   var ldp = ldnode.createServer({
     root: path.join(__dirname, '../resources'),
+    skipWelcomePage: true,
     webid: false
   })
 

--- a/test/integration/header-test.js
+++ b/test/integration/header-test.js
@@ -7,6 +7,7 @@ const serverOptions = {
   root: path.join(__dirname, '../resources/headers'),
   multiuser: false,
   webid: true,
+  skipWelcomePage: true,
   sslKey: path.join(__dirname, '../keys/key.pem'),
   sslCert: path.join(__dirname, '../keys/cert.pem'),
   forceUser: 'https://ruben.verborgh.org/profile/#me'

--- a/test/integration/http-copy-test.js
+++ b/test/integration/http-copy-test.js
@@ -16,6 +16,7 @@ describe('HTTP COPY API', function () {
     sslKey: path.join(__dirname, '../keys/key.pem'),
     sslCert: path.join(__dirname, '../keys/cert.pem'),
     webid: false,
+    skipWelcomePage: true,
     serverUri: address
   })
 

--- a/test/integration/http-test.js
+++ b/test/integration/http-test.js
@@ -12,9 +12,8 @@ chai.use(require('dirty-chai'))
 const { ACL_SUFFIX, META_SUFFIX } = require('../../lib/defaults')
 
 const ldpServer = ldnode.createServer({
-  live: true,
   root: path.join(__dirname, '../resources'),
-  auth: 'oidc',
+  skipWelcomePage: true,
   webid: false
 })
 const server = supertest(ldpServer)

--- a/test/integration/patch-sparql-update-test.js
+++ b/test/integration/patch-sparql-update-test.js
@@ -13,6 +13,7 @@ describe.skip('PATCH through application/sparql-update', function () {
   var ldp = ldnode({
     root: path.join(__dirname, '../resources/sampleContainer'),
     mount: '/test',
+    skipWelcomePage: true,
     webid: false
   })
   var server = supertest(ldp)

--- a/test/integration/patch-test.js
+++ b/test/integration/patch-test.js
@@ -16,6 +16,7 @@ const serverOptions = {
   configPath,
   serverUri,
   multiuser: false,
+  skipWelcomePage: true,
   webid: true,
   sslKey: path.join(__dirname, '../keys/key.pem'),
   sslCert: path.join(__dirname, '../keys/cert.pem'),


### PR DESCRIPTION
* Simplify the new account templating system (do not create template and view copies for customizability)
* Skip setting up welcome tests on integration tests that don't need it.