### PR TITLE
Fix 'rdflib' error when running docker image built from ./Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 sudo: false
-language: node_js
-node_js:
-  - "10"
-  - "12"
 
 addons:
   hosts:
@@ -10,10 +6,34 @@ addons:
     - tim.localhost
     - nicola.localhost
 
-before_install:
-  - npm install -g npm@latest
-
-script:
-  - npm run standard
-  - npm run validate
-  - npm run nyc
+jobs:
+  include:
+  - services:
+    - docker
+    script:
+    - docker build -t life-server .
+    # Run for no more than 5s
+    - timeout 5s docker run life-server
+    - exit_code=$?
+    - echo "docker run exit_code=$exit_code"
+    - |
+      # timeout will have exit code 124.
+      # If docker run was successful or excited due to timeout, that's good.
+      # Otherwise there was an error and we should fail the build.
+      [ "$exit_code" == "0" ] || [ "$exit_code" == "124" ] || travis_terminate 1
+  - language: node_js
+    node_js: "10"
+    install: |
+      npm install -g npm@latest
+    script:
+    - npm run standard
+    - npm run validate
+    - npm run nyc
+  - language: node_js
+    node_js: "12"
+    install: |
+      npm install -g npm@latest
+    script:
+    - npm run standard
+    - npm run validate
+    - npm run nyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ jobs:
     - docker
     script:
     - docker build -t life-server .
-    # Run for no more than 5s
-    - timeout 5s docker run life-server
-    - exit_code=$?
-    - echo "docker run exit_code=$exit_code"
     - |
-      # timeout will have exit code 124.
+      # Run for no more than 5s
+      timeout --kill-after=1 5s docker run life-server
+      exit_code=$?
+      echo "docker run exit_code=$exit_code"
+      # timeout will have exit code 124 or 137 (-k flag)
       # If docker run was successful or excited due to timeout, that's good.
       # Otherwise there was an error and we should fail the build.
-      [ "$exit_code" == "0" ] || [ "$exit_code" == "124" ] || travis_terminate 1
+      [ "$exit_code" == "0" ] || [ "$exit_code" == "124" ] || [ "$exit_code" == "137" ] || travis_terminate 1
   - language: node_js
     node_js: "10"
     install: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,28 @@
-FROM node:8.11.2-onbuild
-EXPOSE 8443
+FROM node:12-slim
+
+# Install git so npm can install git dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash -g root -G sudo -u 1001 life-server
+
+WORKDIR /usr/src/app
+RUN chown -R life-server:root .
+
+USER life-server
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+# Include default configuration
 COPY config.json-default config.json
 RUN openssl req \
     -new \
@@ -10,4 +33,6 @@ RUN openssl req \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" \
     -keyout privkey.pem \
     -out fullchain.pem
+
+EXPOSE 8443
 CMD npm run solid start


### PR DESCRIPTION
Currently, `docker run interopalliance/life-server:6.0.2` will exit right away and show an error like:

```
(node:27) UnhandledPromiseRejectionWarning: Error: Cannot find module 'rdflib'
```

So, first off, it would be nice if our CI system, Travis CI, would check on each commit/PR to make sure that the Dockerfile can be built and then run without this kind of error. So this PR adds that to the travis-ci.yml configuration.
* I've tested this on my fork: https://travis-ci.com/gobengo/node-solid-server/builds/137210358

As for the error: This is happening because of a chain of causes:
* rdflib is in the package.json as a git dependency that doesn't go to the npm registry
* rdflib's package.json has `main: "lib/main.js"`, or similar, but the git repository doesn't have a lib directory. This is built by babel. Often these built artifacts are uploaded to the npm registry, but when depending on things via git, npm will look in the package for an npm script called `prepare` and, if it's present, will run it to sort of build the package. In the case of rdflib, there is a prepare script that would create the lib directory, but this wasn't being run.
* After searching, I found this post that mentions that npm might not run prepare scripts when running as root. https://stackoverflow.com/a/52767310

So the solution was to adjust the Dockerfile such that `npm install` runs not as root, but by another user I called 'life-server'.