### PR TITLE
Dockerfile cmd doesn't use npm, since it doesn't forward SIGINT signa…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN openssl req \
     -out fullchain.pem
 
 EXPOSE 8443
-CMD npm run solid start
+CMD ["node", "./bin/solid", "start"]


### PR DESCRIPTION
…ls (fixes ctrl-c w/ docker run).

Before this, if you built and run the Dockerfile like:
```
docker build -t life-server .
docker run life-server
```

Then you wouldn't be able to stop the resulting process with 'control-c' (send SIGINT signal to interrupt process).
* Instead you would have to open another terminal, `docker ps` to get the id of the running container, then `docker kill <container-id>` to kill it. (`docker ps | grep life-server | cut -f1 -d' ' | xargs docker kill`)
The fix is to not use `npm start` as the Dockerfile command, but to use `node ./bin/solid start` instead. This is related to an issue where npm doesn't forward unix signals to its child processes (like the start script).
* https://github.com/npm/npm/issues/4603

Related links:
* https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#cmd
* https://dev.to/michielmulders/why-we-stopped-using-npm-start-for-running-our-blockchain-core-s-child-processes-1ef4