### PR TITLE
.travis.yml does install npm@latest as before_install not install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       [ "$exit_code" == "0" ] || [ "$exit_code" == "124" ] || [ "$exit_code" == "137" ] || travis_terminate 1
   - language: node_js
     node_js: "12"
-    install: |
+    before_install: |
       npm install -g npm@latest
     script:
     - npm run standard


### PR DESCRIPTION
This fixes the broken travis builds (e.g. https://travis-ci.org/interop-alliance/life-server/jobs/617936223).

There's a step in there that I assume is important, but may not be, to upgrade npm to latest as part of the build.

Before this PR, that was done as a travis 'install' step. I think by specifying it there, that was replacing entirely travis' default node_js install behavior of running something like 'npm install'.

This PR moves the 'upgrade npm' command to before_install, unsetting 'install', and letting the defaults do their job.