### PR TITLE
Refactor New Account API to work off of JSON (instead of form-encoded)

### DIFF
--- a/common/css/spinner.css
+++ b/common/css/spinner.css
@@ -1,0 +1,51 @@
+@keyframes ldio-ny0qf724px9 {
+  0% { transform: rotate(0deg) }
+  50% { transform: rotate(22.5deg) }
+  100% { transform: rotate(45deg) }
+}
+.ldio-ny0qf724px9 > div {
+  transform-origin: 50px 50px;
+  animation: ldio-ny0qf724px9 0.2s infinite linear;
+}
+.ldio-ny0qf724px9 > div div {
+  position: absolute;
+  width: 11px;
+  height: 76px;
+  background: #bbcedd;
+  left: 50px;
+  top: 50px;
+  transform: translate(-50%,-50%);
+}
+.ldio-ny0qf724px9 > div div:nth-child(1) {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+}
+.ldio-ny0qf724px9 > div div:nth-child(6) {
+  width: 40px;
+  height: 40px;
+  background: #fdfdfd;
+  border-radius: 50%;
+}.ldio-ny0qf724px9 > div div:nth-child(3) {
+   transform: translate(-50%,-50%) rotate(45deg)
+ }.ldio-ny0qf724px9 > div div:nth-child(4) {
+    transform: translate(-50%,-50%) rotate(90deg)
+  }.ldio-ny0qf724px9 > div div:nth-child(5) {
+     transform: translate(-50%,-50%) rotate(135deg)
+   }
+.loadingio-spinner-gear-kznxtisnhx {
+  width: 41px;
+  height: 41px;
+  display: inline-block;
+  overflow: hidden;
+  background: none;
+}
+.ldio-ny0qf724px9 {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform: translateZ(0) scale(0.41);
+  backface-visibility: hidden;
+  transform-origin: 0 0; /* see note above */
+}
+.ldio-ny0qf724px9 div { box-sizing: content-box; }

--- a/common/js/ready.js
+++ b/common/js/ready.js
@@ -1,0 +1,10 @@
+/**
+ * Util helper function for common use in internal pages.
+ */
+function onDocumentReady (fn) {
+  if(document.readyState !== 'loading') {
+    fn()
+  } else {
+    document.addEventListener('DOMContentLoaded', fn)
+  }
+}

--- a/config.default.js
+++ b/config.default.js
@@ -48,6 +48,9 @@ module.exports = {
    * Feature Flags
    */
   features: {
+    // Is creation of new accounts enabled? Locks the /register endpoint
+    allowAccountCreation: true,
+
     // Register a wallet for new users, during account creation?
     registerWalletOnSignup: false,
 

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -1,54 +1,105 @@
-<form method="post" action="/api/accounts/new">
-  <div class="form-group">
-    {{#if error}}
-      <div class="row">
-        <div class="col-md-12">
-          <p class="text-danger"><strong>{{error}}</strong></p>
-        </div>
-      </div>
-    {{/if}}
+<form id="registerForm">
+  {{#if error}}
     <div class="row">
-      <div class="col-md-6">
-        <label for="username">Display Name:</label>
-        <p>Something to display in the nav bar, to indicate you're logged in etc.</p>
-        <input type="text" class="form-control" name="username" id="username" placeholder="alice" />
+      <div class="col s12">
+        <p class="text-danger"><strong>{{error}}</strong></p>
       </div>
-      <div class="col-md-6">&nbsp;</div>
     </div>
-    <div class="row">
-      <div class="col-md-6">
-        <label for="email">Recovery Email:</label>
-        <p>Your email will only used for account recovery.</p>
-        <input type="email" class="form-control" name="email" id="email" />
-      </div>
-      <div class="col-md-6">&nbsp;</div>
+  {{/if}}
+
+  <div class="row">
+    <div class="input-field col s6">
+      <i class="material-icons prefix">email</i>
+      <input type="email" name="email" id="email" placeholder="Email" />
+      <label for="email">Recovery Email:</label>
     </div>
-    <div class="row">
-      <div class="col-md-6">
-        <label for="password">Password:</label>
-        <input type="password" class="form-control" name="password" id="password" />
-      </div>
-      <div class="col-md-6">&nbsp;</div>
+    <div class="input-field col s6">
+      <p>Your email will only used for account recovery and other
+        administrative emails.</p>
     </div>
-    <input type="hidden" name="returnToUrl" value="{{returnToUrl}}" />
   </div>
 
-  <div class="form-group">
-    <div class="row">
-      <div class="col-md-2">
-        <button type="submit" class="btn btn-primary" id="register">Register ></button>
+  <div class="row">
+    <div class="input-field col s6">
+      <i class="material-icons prefix">account_circle</i>
+      <input placeholder="Username" id="username" name="username" type="text">
+      <label for="username">Display Username:</label>
+    </div>
+    <div class="input-field col s6">
+      <p>Something to display in the nav bar, to indicate you're logged in.</p>
+    </div>
+  </div>
 
-        {{> auth/auth-hidden-fields}}
-      </div>
+  <div class="row">
+    <div class="input-field col s6">
+      <i class="material-icons prefix">vpn_key</i>
+      <input id="password" id="password" name="password" type="password">
+      <label for="password">Password:</label>
+    </div>
+  </div>
 
-      <div class="col-md-10">
-        <div>Already have an account?
-          <a class="btn btn-xs btn-default"
-             href="{{{loginUrl}}}">
-            Log In
-          </a>
-        </div>
+  <input type="hidden" name="returnToUrl" value="{{returnToUrl}}" />
+
+  <div class="row">
+    <div class="col s6 valign-wrapper">
+      <button type="submit" class="btn btn-primary" id="registerBtn">Register ></button>
+
+      <div class="loadingio-spinner-gear-kznxtisnhx hide" id="spinner"><div class="ldio-ny0qf724px9">
+        <div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+      </div></div>
+
+      {{> auth/auth-hidden-fields}}
+    </div>
+
+    <div class="col s6" id="loginSection">
+      <div>Already have an account?
+        <a class="btn btn-xs btn-default"
+           href="{{{loginUrl}}}">
+          Log In
+        </a>
       </div>
     </div>
   </div>
+
 </form>
+<script src="/common/js/ready.js"></script>
+
+<script>
+  async function submitRegisterForm () {
+    document.getElementById('registerBtn').disabled = 'disabled'
+    document.getElementById('spinner').classList.remove('hide')
+    document.getElementById('loginSection').classList.add('hide')
+
+    const userData = {}
+    for (const field of ['email', 'username', 'password']) {
+      userData[field] = document.getElementById(field).value
+    }
+
+    console.log('Registering:', userData)
+    try {
+      const response = await fetch('/api/accounts/new', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(userData)
+      })
+
+      if (!response.ok) {
+        throw new Error('Error: ' + await response.text())
+      }
+
+      console.log(response)
+    } catch (e) {
+      console.error('Error:', e.message)
+    }
+
+  }
+
+  onDocumentReady(() => { // from /common/js/ready.js
+    document.getElementById('registerBtn')
+      .addEventListener('click', submitRegisterForm)
+  })
+</script>
+
+

--- a/default-views/account/register-form.hbs
+++ b/default-views/account/register-form.hbs
@@ -1,11 +1,16 @@
 <form id="registerForm">
   {{#if error}}
+    <!--  server-side error  -->
     <div class="row">
       <div class="col s12">
         <p class="text-danger"><strong>{{error}}</strong></p>
       </div>
     </div>
   {{/if}}
+
+  <div class="row">
+    <div class="col s12 red lighten-4 hide" id="errorMessage"></div>
+  </div>
 
   <div class="row">
     <div class="input-field col s6">
@@ -65,17 +70,24 @@
 <script src="/common/js/ready.js"></script>
 
 <script>
+  function resetRegisterButton () {
+    document.getElementById('registerBtn').disabled = ''
+    document.getElementById('spinner').classList.add('hide')
+    document.getElementById('loginSection').classList.remove('hide')
+  }
+
   async function submitRegisterForm () {
+
     document.getElementById('registerBtn').disabled = 'disabled'
     document.getElementById('spinner').classList.remove('hide')
     document.getElementById('loginSection').classList.add('hide')
+    document.getElementById('errorMessage').classList.add('hide')
 
     const userData = {}
     for (const field of ['email', 'username', 'password']) {
       userData[field] = document.getElementById(field).value
     }
 
-    console.log('Registering:', userData)
     try {
       const response = await fetch('/api/accounts/new', {
         method: 'POST',
@@ -86,12 +98,23 @@
       })
 
       if (!response.ok) {
-        throw new Error('Error: ' + await response.text())
+        const error = new Error('Registration error.')
+        error.cause = await response.json()
+        throw error
       }
 
-      console.log(response)
+      const responseData = await response.json()
+      window.location.href = responseData.redirect || '/'
     } catch (e) {
-      console.error('Error:', e.message)
+      resetRegisterButton()
+      const cause = e.cause || {}
+      let errorMessage = cause.message || e.message
+      if (errorMessage === 'Failed to fetch') {
+        errorMessage = 'Could not reach the server.'
+      }
+      document.getElementById('errorMessage').innerHTML = errorMessage
+      document.getElementById('errorMessage').classList.remove('hide')
+      console.error(e)
     }
 
   }

--- a/default-views/account/register.hbs
+++ b/default-views/account/register.hbs
@@ -1,6 +1,5 @@
 <div class="container">
-  <h4>Register</h4>
-</div>
-<div class="container">
+  <h2 class="header">Register</h2>
+
   {{> account/register-form}}
 </div>

--- a/default-views/layouts/main.hbs
+++ b/default-views/layouts/main.hbs
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Life Server: {{title}}</title>
-  <link rel="stylesheet" href="/common/css/bootstrap.min.css">
+  <link rel="stylesheet" href="/common/css/bootstrap.min.css" />
 </head>
 <body>
 {{{body}}}

--- a/default-views/layouts/material.hbs
+++ b/default-views/layouts/material.hbs
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LifeServer: {{title}}</title>
+  <!--Import Google Icon Font-->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+
+  <!-- Compiled and minified Materialize JS/CSS -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
+
+  <link rel="stylesheet" href="/common/css/spinner.css" />
+</head>
+<body>
+
+{{{body}}}
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/default-views/layouts/wallet.hbs
+++ b/default-views/layouts/wallet.hbs
@@ -12,6 +12,7 @@
 
   <script src="https://unpkg.com/credential-handler-polyfill@2.1.1/dist/credential-handler-polyfill.min.js"></script>
   <script src="https://unpkg.com/web-credential-handler@1.0.1/dist/web-credential-handler.min.js"></script>
+  <script src="/common/js/ready.js"></script>
 </head>
 <body>
 <script>
@@ -19,14 +20,6 @@
   const MEDIATOR = 'https://authorization.localhost:33443/mediator' + '?origin=' +
     encodeURIComponent(window.location.origin)
   const WALLET_LOCATION = '{{serverUri}}'
-
-  function onDocumentReady (fn) {
-    if(document.readyState !== 'loading') {
-      fn()
-    } else {
-      document.addEventListener('DOMContentLoaded', fn)
-    }
-  }
 </script>
 
 {{{body}}}

--- a/lib/account-mgmt/create-account-request.js
+++ b/lib/account-mgmt/create-account-request.js
@@ -83,7 +83,7 @@ class CreateAccountRequest extends AuthRequest {
       this.validate()
       await this.createAccount()
     } catch (error) {
-      this.error(error)
+      this.errorJson(error)
     }
   }
 
@@ -187,6 +187,19 @@ class CreateAccountRequest extends AuthRequest {
   }
 
   /**
+   * Calls the appropriate form to display to the user.
+   * Serves as an error handler for this request workflow.
+   *
+   * @param error {Error}
+   */
+  errorJson (error) {
+    const statusCode = error.code || 400
+
+    logger.error(error)
+    this.response.status(statusCode).json({ message: error.message })
+  }
+
+  /**
    * Sends response to user (directs the user to the next step of registration).
    *
    * @param userAccount {UserAccount}
@@ -200,7 +213,7 @@ class CreateAccountRequest extends AuthRequest {
       redirectUrl = this.returnToUrl ||
         this.accountManager.accountUriFor(userAccount.username)
     }
-    this.response.redirect(redirectUrl)
+    this.response.json({ redirect: redirectUrl })
   }
 }
 

--- a/lib/account-mgmt/create-account-request.js
+++ b/lib/account-mgmt/create-account-request.js
@@ -102,8 +102,8 @@ class CreateAccountRequest extends AuthRequest {
       logger.error(error)
       this.response.status(error.statusCode)
     }
-
-    this.response.render('account/register', { title: 'Register', ...params })
+    this.response.render('account/register',
+      { title: 'Register', layout: 'material', ...params })
   }
 
   /**

--- a/lib/account-mgmt/routes.js
+++ b/lib/account-mgmt/routes.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const express = require('express')
-// const bodyParserForm = require('body-parser').urlencoded({ extended: false })
+const bodyParserJson = express.json()
 const bodyParserForm = express.urlencoded({ extended: false })
 const { logger } = require('../logger')
 const HttpError = require('standard-http-error')
@@ -39,7 +39,7 @@ function middleware (accountManager) {
   router.head('/', checkAccountExists(accountManager))
 
   router.post('/api/accounts/new', checkFeatureFlag('allowAccountCreation'),
-    bodyParserForm, CreateAccountRequest.post())
+    bodyParserJson, CreateAccountRequest.post())
   router.get(['/register', '/api/accounts/new'], checkFeatureFlag('allowAccountCreation'),
     CreateAccountRequest.get())
 

--- a/lib/account-mgmt/routes.js
+++ b/lib/account-mgmt/routes.js
@@ -1,14 +1,29 @@
 'use strict'
 
 const express = require('express')
-const bodyParser = require('body-parser').urlencoded({ extended: false })
+// const bodyParserForm = require('body-parser').urlencoded({ extended: false })
+const bodyParserForm = express.urlencoded({ extended: false })
 const { logger } = require('../logger')
+const HttpError = require('standard-http-error')
 
+const { ServerRequest } = require('../server-request')
 const { CreateAccountRequest } = require('./create-account-request')
 const { RegisterWalletRequest } = require('./register-wallet-request')
 const { WalletRequest } = require('./wallet-request')
 const DeleteAccountRequest = require('./delete-account-request')
 const DeleteAccountConfirmRequest = require('./delete-account-confirm-request')
+
+function checkFeatureFlag (name) {
+  return (req, res, next) => {
+    const { host: { features } } = ServerRequest.baseOptions(req, res)
+
+    if (features[name] !== undefined && !features[name]) {
+      logger.warn(`Feature '${name}' is disabled.`)
+      return next(new HttpError(400, 'This feature or API endpoint is disabled.'))
+    }
+    next()
+  }
+}
 
 /**
  * Returns an Express router for providing user account related middleware
@@ -23,8 +38,10 @@ function middleware (accountManager) {
 
   router.head('/', checkAccountExists(accountManager))
 
-  router.post('/api/accounts/new', bodyParser, CreateAccountRequest.post())
-  router.get(['/register', '/api/accounts/new'], CreateAccountRequest.get())
+  router.post('/api/accounts/new', checkFeatureFlag('allowAccountCreation'),
+    bodyParserForm, CreateAccountRequest.post())
+  router.get(['/register', '/api/accounts/new'], checkFeatureFlag('allowAccountCreation'),
+    CreateAccountRequest.get())
 
   router.get('/api/wallet/new', RegisterWalletRequest.get())
   router.post('/api/wallet/new', RegisterWalletRequest.post())
@@ -34,10 +51,10 @@ function middleware (accountManager) {
   router.get('/api/wallet/store', WalletRequest.storeOperationUi())
 
   router.get('/account/delete', DeleteAccountRequest.get())
-  router.post('/account/delete', bodyParser, DeleteAccountRequest.post())
+  router.post('/account/delete', bodyParserForm, DeleteAccountRequest.post())
 
   router.get('/account/delete/confirm', DeleteAccountConfirmRequest.get())
-  router.post('/account/delete/confirm', bodyParser,
+  router.post('/account/delete/confirm', bodyParserForm,
     DeleteAccountConfirmRequest.post())
 
   return router

--- a/lib/server-request.js
+++ b/lib/server-request.js
@@ -97,7 +97,7 @@ class ServerRequest {
         const request = this.fromIncoming(req, res)
         await request.handlePost()
       } catch (error) {
-        logger.error('Error in ServerRequest.post:', error)
+        logger.error('Error in ServerRequest.post:' + error)
         next(error)
       }
     }

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "standard": "standard '{bin,examples,lib,test}/**/*.js'",
     "validate": "node ./test/validate-turtle.js",
     "test": "npm run standard && npm run validate && npm run nyc",
+    "test-bail": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 mocha -b",
     "nyc": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 nyc --reporter=html mocha",
     "mocha": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 mocha",
     "clean": "rm -rf config/templates config/views",

--- a/test/integration/account-creation-oidc-test.js
+++ b/test/integration/account-creation-oidc-test.js
@@ -42,12 +42,6 @@ describe('AccountManager (OIDC account creation tests)', () => {
     await fs.remove(path.join(dbPath, 'users'))
   })
 
-  // FIXME: Does this test even make sense?
-  it.skip('should expect a 404 on GET /accounts', async () => {
-    return supertest(serverUri).get('/api/accounts')
-      .expect(404) // actually throws a 401 Unauthorized
-  })
-
   describe('accessing accounts', () => {
     it('should be able to access public file of an account', async () => {
       return supertest('https://tim.' + host)
@@ -77,32 +71,37 @@ describe('AccountManager (OIDC account creation tests)', () => {
     it('should not create WebID if no username is given', async () => {
       return supertest('https://nicola.' + host)
         .post('/api/accounts/new')
-        .send('username=&password=12345')
+        .send({ password: '12345' })
+        .set('Accept', 'application/json')
         .expect(400)
     })
 
     it('should not create WebID if no password is given', async () => {
       return supertest('https://nicola.' + host)
         .post('/api/accounts/new')
-        .send('username=nicola&password=')
+        .send({ username: 'nicola' })
+        .set('Accept', 'application/json')
         .expect(400)
     })
 
     it('should not create a WebID if it already exists', async () => {
       const subdomain = supertest('https://nicola.' + host)
       await subdomain.post('/api/accounts/new')
-        .send('username=nicola&password=12345')
-        .expect(302)
+        .send({ username: 'nicola', password: '12345' })
+        .set('Accept', 'application/json')
+        .expect(200)
       return subdomain.post('/api/accounts/new')
-        .send('username=nicola&password=12345')
+        .send({ username: 'nicola', password: '12345' })
+        .set('Accept', 'application/json')
         .expect(400)
     })
 
     it('should create the default folders', async () => {
       const subdomain = supertest('https://nicola.' + host)
       await subdomain.post('/api/accounts/new')
-        .send('username=nicola&password=12345')
-        .expect(302)
+        .send({ username: 'nicola', password: '12345' })
+        .set('Accept', 'application/json')
+        .expect(200)
 
       const domain = host.split(':')[0]
       const card = read(path.join('accounts', 'nicola.' + domain,
@@ -123,8 +122,9 @@ describe('AccountManager (OIDC account creation tests)', () => {
     it('should link WebID to the root account', async () => {
       const subdomain = supertest('https://nicola.' + host)
       await subdomain.post('/api/accounts/new')
-        .send('username=nicola&password=12345')
-        .expect(302)
+        .send({ username: 'nicola', password: '12345' })
+        .set('Accept', 'application/json')
+        .expect(200)
 
       const data = await subdomain.get('/.meta')
         .expect(200)


### PR DESCRIPTION
Refactor `/register` page (account creation):

* Form now submits JSON to the account API endpoint.
* Account registration request receives and returns JSON.
* Uses Materialize CSS instead of Bootstrap.

Partly addresses issue #57.